### PR TITLE
[FIX] Prevent FAB click events when it's invisible.

### DIFF
--- a/app/src/main/res/xml/scene_main.xml
+++ b/app/src/main/res/xml/scene_main.xml
@@ -22,7 +22,12 @@
             android:scaleY="0.0"
             app:layout_constraintBottom_toTopOf="@id/fab_main"
             app:layout_constraintLeft_toLeftOf="@id/fab_main"
-            app:layout_constraintRight_toRightOf="@id/fab_main" />
+            app:layout_constraintRight_toRightOf="@id/fab_main">
+
+            <CustomAttribute
+                app:attributeName="clickable"
+                app:customBoolean="true" />
+        </Constraint>
 
         <Constraint
             android:id="@+id/tv_mask_rotation_label"
@@ -44,7 +49,12 @@
             android:scaleY="0.0"
             app:layout_constraintBottom_toTopOf="@id/fab_mask_rotation"
             app:layout_constraintLeft_toLeftOf="@id/fab_main"
-            app:layout_constraintRight_toRightOf="@id/fab_main" />
+            app:layout_constraintRight_toRightOf="@id/fab_main">
+
+            <CustomAttribute
+                app:attributeName="clickable"
+                app:customBoolean="true" />
+        </Constraint>
 
         <Constraint
             android:id="@+id/tv_1339call_label"
@@ -65,7 +75,12 @@
             android:scaleY="0.0"
             app:layout_constraintBottom_toTopOf="@id/fab_1339call"
             app:layout_constraintLeft_toLeftOf="@id/fab_main"
-            app:layout_constraintRight_toRightOf="@id/fab_main" />
+            app:layout_constraintRight_toRightOf="@id/fab_main">
+
+            <CustomAttribute
+                app:attributeName="clickable"
+                app:customBoolean="true" />
+        </Constraint>
 
         <Constraint
             android:id="@+id/tv_corona_manual_label"
@@ -86,7 +101,12 @@
             android:scaleY="0.0"
             app:layout_constraintBottom_toTopOf="@id/fab_corona_manual"
             app:layout_constraintLeft_toLeftOf="@id/fab_main"
-            app:layout_constraintRight_toRightOf="@id/fab_main" />
+            app:layout_constraintRight_toRightOf="@id/fab_main">
+
+            <CustomAttribute
+                app:attributeName="clickable"
+                app:customBoolean="true" />
+        </Constraint>
 
         <Constraint
             android:id="@+id/tv_corona_status_label"
@@ -120,7 +140,12 @@
             android:scaleY="1.0"
             app:layout_constraintBottom_toTopOf="@id/fab_main"
             app:layout_constraintLeft_toLeftOf="@id/fab_main"
-            app:layout_constraintRight_toRightOf="@id/fab_main" />
+            app:layout_constraintRight_toRightOf="@id/fab_main">
+
+            <CustomAttribute
+                app:attributeName="clickable"
+                app:customBoolean="false" />
+        </Constraint>
 
         <Constraint
             android:id="@+id/tv_mask_rotation_label"
@@ -140,7 +165,12 @@
             android:scaleY="1.0"
             app:layout_constraintBottom_toTopOf="@id/fab_mask_rotation"
             app:layout_constraintLeft_toLeftOf="@id/fab_main"
-            app:layout_constraintRight_toRightOf="@id/fab_main" />
+            app:layout_constraintRight_toRightOf="@id/fab_main">
+
+            <CustomAttribute
+                app:attributeName="clickable"
+                app:customBoolean="false" />
+        </Constraint>
 
         <Constraint
             android:id="@+id/tv_1339call_label"
@@ -159,7 +189,12 @@
             android:scaleY="1.0"
             app:layout_constraintBottom_toTopOf="@id/fab_1339call"
             app:layout_constraintLeft_toLeftOf="@id/fab_main"
-            app:layout_constraintRight_toRightOf="@id/fab_main" />
+            app:layout_constraintRight_toRightOf="@id/fab_main">
+
+            <CustomAttribute
+                app:attributeName="clickable"
+                app:customBoolean="false" />
+        </Constraint>
 
         <Constraint
             android:id="@+id/tv_corona_manual_label"
@@ -178,7 +213,12 @@
             android:scaleY="1.0"
             app:layout_constraintBottom_toTopOf="@id/fab_corona_manual"
             app:layout_constraintLeft_toLeftOf="@id/fab_main"
-            app:layout_constraintRight_toRightOf="@id/fab_main" />
+            app:layout_constraintRight_toRightOf="@id/fab_main">
+
+            <CustomAttribute
+                app:attributeName="clickable"
+                app:customBoolean="false" />
+        </Constraint>
 
         <Constraint
             android:id="@+id/tv_corona_status_label"


### PR DESCRIPTION
When I changed animation files to MotionLayout, I didn't expect user interactions when scale is 0.
Added custom attribute clickable to fix this situation.